### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,7 +10,7 @@ jobs:
   cancel_previous:
     runs-on: ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.9.1
+    - uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
       with:
         workflow_id: ${{ github.event.workflow.id }}
         
@@ -18,7 +18,7 @@ jobs:
     needs: cancel_previous
     runs-on: macos-latest
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
     needs: cancel_previous
     runs-on: ubuntu-latest
     steps:
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@cdbe0f7f4c77929b6580e71983e8606e55ffe7e4 # v1.26.0
       with:
         swift-version: "5.7"
     - uses: actions/checkout@v2


### PR DESCRIPTION
REF: [DX-516](https://linear.app/customerio/issue/DX-516/update-all-github-action-libraries-to-use-sha-instead-of-version)\n\nPins GitHub Actions as part of DX-516.